### PR TITLE
parser_pg completed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
   docker:
     strategy:
       matrix:
-        POSTGRES_VERSION: [12, 13]
+        POSTGRES_VERSION: [ 12, 13]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/:
+++ b/:
@@ -1,0 +1,177 @@
+import sys
+from lark import Lark, Transformer
+
+def parse_create(sql):
+    '''
+    Example expected output:
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "t1", "condition": "", "join_type": "FROM"}, 
+    {"table_name": "testjoin2", "table_alias": "t2", "condition": "using (id)", "join_type": "INNER JOIN"}]',
+    'rollup_name': 'testjoin_rollup1',
+    'groups': [['t1.name', '"t1.name"']],
+    'columns': [['sum(t1.num)', 'sum_num'], ['sum(t2.foo)', 'sum_foo']],
+    'where_clause': None, 'having_clause': None}]
+    '''
+    dict = parse(sql)
+    infos = []                                              
+    infos.append({
+#       'joininfos' :
+#       'groups' : [xs['fields'][0] for xs in dict[0]['stmt']['groupClause']]
+#       'columns' :[[xs['val']['funcname'][0],xs['val']['args'][0]['fields'][0],xs['name']] for xs in dict[0]['stmt']['targetList'] if dict[0]['stmt']['targetList'][1]['val']['agg_star']=='False'],
+#                  [[xs['val']['funcname'][0],'*',xs['name']] for xs in m[0]['stmt']['targetList'] if dict[0]['stmt']['targetList'][1]['val']['agg_star']=='True'] 
+#       'where_clause': dict[0]['stmt']['whereClause']
+#       'having_clause': dict[0]['stmt']['havingClause']
+        })
+    return infos
+
+
+#Lark automagically creates a tree that represents the parsed text according to the grammar
+grammar = r"""
+    ?value: dict
+          | list
+          | ESCAPED_STRING     ->string
+          | NAME               -> name   
+          | SIGNED_NUMBER      -> number
+          | "true"             -> true
+          | "false"            -> false
+          | "<>"             -> null
+    
+    list: "(" [value*] ")"
+    dict: "{" value [pair*] "}"
+    pair : ":"NAME value
+
+    NAME: /[a-zA-Z_.0-9]+/
+    
+
+    %import common.ESCAPED_STRING
+    %import common.SIGNED_NUMBER
+    %import common.WS
+    %ignore WS
+    """
+
+class Transformer(Transformer):
+    '''
+    A class with methods corresponding to branch names. 
+    For each branch, the appropriate method will be called 
+    with the children of the branch as its argument, and 
+    its return value will replace the branch in the tree.
+    '''
+    def string(self, s):
+        '''
+        Example input:
+        [Tree('string', [Token('ESCAPED_STRING', '"t1"')]),Tree('string', [Token('ESCAPED_STRING', '"num"')])]
+        Example output:
+        ['t1','num']
+       '''
+        (s,) = s
+        return s[1:-1]
+    def number(self, n):
+        '''
+        Example input:
+        Tree('number', [Token('SIGNED_NUMBER', '40')])
+        Example output:
+        40
+        '''
+        (n,) = n
+        return int(n)                        
+    def pair(self,key_value):
+        k, v = key_value
+        return str(k),v
+                       
+    list = list   
+#   pair = tuple
+    dict = dict
+
+    #NAME = lambda self, n: n
+    name  = lambda self,n: ('TYPE',str(n[0]))
+    null = lambda self, _: None
+    true = lambda self, _: True
+    false = lambda self, _: False
+
+parser = Lark(grammar, start='value', lexer='standard')
+
+import pprint
+def parse(text):
+    '''
+    >>> pprint.pprint(parse(sql0))
+    '''
+    tree = parser.parse(text)
+    return Transformer().transform(tree)
+
+def parse_tree(text):
+    print(parser.parse(text).pretty())
+
+################################################################################
+# internal helper functions
+################################################################################
+
+
+#def _getcols(sql):
+#    if sql[0]['stmt']['targetList']
+
+
+################################################################################
+# postgres's parse tree on example sql expressions
+################################################################################
+
+#sql0 = '''
+#CREATE INCREMENTAL MATERIALIZED VIEW example AS (
+#    SELECT
+#        count(*),
+#        sum(num) AS sum
+#    FROM tablename
+#    WHERE (test>=from)
+#    GROUP BY a,b,c
+#    HAVING foo=bar
+#);
+#'''
+sql0='''
+ ({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16} {RESTARGET :name sum :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 38}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 34} :location 34}) :fromClause ({RANGEVAR :schemaname <> :relname tablename :inh true :relpersistence p :alias <> :location 59}) :whereClause {AEXPR  :name (">=") :lexpr {COLUMNREF :fields ("test") :location 80} :rexpr {COLUMNREF :fields ("from") :location 86} :location 84} :groupClause ({COLUMNREF :fields ("a") :location 107} {COLUMNREF :fields ("b") :location 109} {COLUMNREF :fields ("c") :location 111}) :havingClause {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("foo") :location 124} :rexpr {COLUMNREF :fields ("bar") :location 128} :location 127} :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 132})
+'''
+
+sql1='''
+ ({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 43}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 68}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause<> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 73})
+'''
+
+sql2='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 8} :location 8}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 35}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 60} {COLUMNREF :fields ("num") :location 65}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 69})
+'''
+
+sql3='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name sum :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 21}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 17} :location 17} {RESTARGET :name count_all :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 42} :location 42} {RESTARGET :name <> :indirection <> :val{FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 79}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 73} :location 73} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("max") :args ({COLUMNREF :fields ("num") :location 97}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 93} :location 93} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("min") :args ({COLUMNREF :fields ("num") :location 115}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 111} :location 111}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 129}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 154}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 159})
+'''
+
+sql4='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name sum :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 20}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 16} :location 16} {RESTARGET :name count_all :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 41} :location 41} {RESTARGET :name <> :indirection <> :val{FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 78}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 72} :location 72} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("max") :args ({COLUMNREF :fields ("num") :location 96}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 92} :location 92} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("min") :args ({COLUMNREF :fields ("num") :location 114}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 110} :location 110}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 128}) :whereClause <> :groupClause <> :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 140})
+'''
+
+sql5='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({AEXPR  :name ("+") :lexpr {AEXPR  :name ("*") :lexpr {COLUMNREF :fields ("num") :location 20} :rexpr {COLUMNREF :fields ("num") :location 24} :location 23} :rexpr {A_CONST :val 2 :location 30} :location 28}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 16} :location 16} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("max") :args ({A_CONST :val 1 :location 46}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 42} :location 42} {RESTARGET :name <> :indirection <> :val {AEXPR  :name ("+") :lexpr {AEXPR  :name ("/") :lexpr {AEXPR  :name ("+") :lexpr {FUNCCALL :funcname ("max") :args ({AEXPR  :name ("*") :lexpr {AEXPR  :name ("+") :lexpr {A_CONST :val 1 :location 64} :rexpr {COLUMNREF :fields ("num") :location 71} :location 66} :rexpr {A_CONST :val 2 :location 79} :location 78}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 59} :rexpr {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 90}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 84} :location 82} :rexpr {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 96} :location 95} :rexpr {AEXPR  :name ("/") :lexpr {AEXPR  :name ("+") :lexpr {FUNCCALL :funcname ("max") :args ({AEXPR  :name ("*") :lexpr {AEXPR  :name ("+") :lexpr {A_CONST :val 1 :location 121} :rexpr {COLUMNREF :fields ("num") :location 128} :location 123} :rexpr {A_CONST :val 2 :location 136} :location 135}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 116} :rexpr {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 147}) :agg_order <> :agg_filter <> :agg_within_group false:agg_star false :agg_distinct false :func_variadic false :over <> :location 141} :location 139} :rexpr {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 153} :location 152} :location 113} :location 58}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 171}) :whereClause <> :groupClause <> :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 184})
+ '''
+
+sql6='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 17} :location 17}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 44} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 63} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 97}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 102})
+'''
+
+sql7='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 43} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 68} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("testjoin1" "id") :location 81} :rexpr {COLUMNREF :fields ("testjoin2" "id") :location 94} :location 93} :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 120}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 125})
+'''
+
+sql8='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({JOINEXPR :jointype 1 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t1 :colnames <>} :location 43} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias {ALIAS :aliasname t2 :colnames <>} :location 74} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("testjoin1" "id") :location 93} :rexpr {COLUMNREF :fields ("testjoin2" "id") :location 106} :location 105} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin3 :inh true :relpersistence p :alias {ALIAS :aliasname t3 :colnames <>} :location 139} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("testjoin1" "name") :location 158} :rexpr {COLUMNREF :fields ("testjoin3" "name") :location 173} :location 172} :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 201}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 207})
+'''
+
+sql9='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 21}) :agg_order <>:agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 17} :location 17} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("foo") :location 39}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 35} :location 35}) :fromClause ({JOINEXPR :jointype 2 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 53} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 77} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 111}) :havingClause <> :windowClause <>:valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 116})
+'''
+
+sql10='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 20}) :agg_order <>:agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 34} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 53} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 87}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <>:limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 92})
+'''
+
+sql11='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name sum_num :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("t1" "num") :location 12}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 8} :location 8} {RESTARGET :name sum_foo :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("t2" "foo") :location 40}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 36} :location 36}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t1 :colnames <>} :location 68} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias {ALIAS :aliasname t2 :colnames <>} :location 91} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("t1" "name") :location 127}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 135})
+'''
+
+sql12='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count_t1 :indirection <> :val {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("t1" "num") :location 14}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 8} :location 8} {RESTARGET :name count_t2 :indirection <> :val {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("t2" "num") :location 45}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 39}:location 39}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t1 :colnames<>} :location 79} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t2 :colnames <>} :location 102} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t1" "id") :location 120} :rexpr {COLUMNREF :fields ("t2" "num") :location 128} :location 126} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t3 :colnames <>} :location 148} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t2" "id") :location 166} :rexpr {COLUMNREF :fields ("t3" "num") :location 174} :location 172} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t4 :colnames <>} :location 194} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t3" "id") :location 212} :rexpr {COLUMNREF :fields ("t4" "num") :location 220} :location 218} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t5 :colnames <>} :location 240} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t4" "id") :location 258} :rexpr {COLUMNREF :fields ("t5" "num") :location 266} :location 264} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t6 :colnames <>} :location 286} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t5" "id") :location 304} :rexpr {COLUMNREF :fields ("t6" "num") :location 312} :location 310} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t7 :colnames <>} :location 332} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t6" "id") :location 350} :rexpr {COLUMNREF :fields ("t7" "num") :location 358} :location 356} :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("t1" "name") :location 379}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 388})
+'''

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/mikeizbicki/pg_rollup/workflows/tests/badge.svg)](https://github.com/mikeizbicki/pg_rollup/actions)
 
-## TODO
+## TODO~
 
 easy:
 

--- a/pgrollup--1.0.sql
+++ b/pgrollup--1.0.sql
@@ -615,7 +615,7 @@ RETURNS VOID AS $$
     import pgrollup.parsing
     cmds = pgrollup.parsing.parse_create(text)
     for cmd in cmds:
-        sql = f'''
+        sql = '''
         SELECT create_rollup_internal(
             $1,
             columns => $2,
@@ -679,8 +679,8 @@ RETURNS TEXT AS $$
         '''
         helper funcions that returns the type of expr
         '''
-        sql = (f'''
-            select {expr}
+        sql = ('''
+            select '''+expr+'''
             '''
             +
             ''.join([
@@ -694,13 +694,13 @@ RETURNS TEXT AS $$
             ''')
         res = plpy.execute(sql)
         t_oid = res.coltypes()[0]
-        sql = f'select typname,typlen from pg_type where oid={t_oid} limit 1;'
+        sql = 'select typname,typlen from pg_type where oid='+str(t_oid)+' limit 1;' 
         row = plpy.execute(sql)[0]
         return row
 
 
     # get a list of all algebras
-    sql = f'select * from algebra;'
+    sql = 'select * from algebra;'
     rows = plpy.execute(sql)
     all_algebras = list(rows)
 
@@ -776,13 +776,13 @@ RETURNS TEXT AS $$
         type = get_type(expr)
 
         # get the algebra dictionary and key
-        sql = f"select * from algebra where name='{algebra}';"
+        sql = "select * from algebra where name='"+algebra+"';"
         res = list(plpy.execute(sql))
         if len(res)==1:
             algebra_dictionary = res[0]
             key = pgrollup.Key(expr,type,name,algebra_dictionary)
         else:
-            plpy.error(f'algbera {algebra} not found in the algebra table')
+            plpy.error('algbera '+algebra+' not found in the algebra table')
 
         # add column info
         columns_raw_list.append(key)
@@ -800,8 +800,8 @@ RETURNS TEXT AS $$
 
         for dep in deps:
             matched = False
-            if f'{dep}({expr})' not in raw_columns:
-                raw_columns.append(f'{dep}({expr})')
+            if dep+'('+expr+')' not in raw_columns:
+                raw_columns.append(dep+'('+expr+')')
 
     # if there are any duplicate names in columns_raw_list, throw an error;
     # this should never happen, and is simply a consistency check
@@ -809,12 +809,12 @@ RETURNS TEXT AS $$
     duplicate_names = [item for item, count in collections.Counter(names).items() if count > 1]
     if len(duplicate_names) > 0:
         plpy.warning('names='+str(names))
-        plpy.error(f'duplicate names in columns: '+str(duplicate_names))
+        plpy.error('duplicate names in columns: '+str(duplicate_names))
 
     # check if the table is temporary
     is_temp = False
     for joininfo in joininfos:
-        sql = f"SELECT relpersistence='t' as is_temp FROM pg_class where relname='{joininfo['table_name']}'"
+        sql = "SELECT relpersistence='t' as is_temp FROM pg_class where relname='"+joininfo['table_name']+"'"
         is_temp = is_temp or plpy.execute(sql)[0]['is_temp']
 
     # compute the information needed for manual/cron rollups
@@ -822,43 +822,43 @@ RETURNS TEXT AS $$
         rollup_column = joininfo.get('rollup_column')
         table_name = joininfo['table_name']
         if rollup_column:
-            event_id_sequence_name = f"{table_name}_{rollup_column}_seq"
+            event_id_sequence_name = table_name+"_"+rollup_column+"_seq"
         else:
             # no rollup_column was given, so we try to use the primary key
-            sql=f'''
+            sql="""
             SELECT ind_column.attname AS pk
             FROM pg_class tbl
             JOIN pg_index ind ON ind.indrelid = tbl.oid
             JOIN pg_class ind_table ON ind_table.oid = ind.indexrelid
             JOIN pg_attribute ind_column ON ind_column.attrelid = ind_table.oid
-            WHERE tbl.relname = '{table_name}'
+            WHERE tbl.relname = '"""+table_name+"""'
               AND ind.indisprimary;
-            '''
+            """
             pks = list(plpy.execute(sql))
 
             event_id_sequence_name = None
             rollup_column = None
             if len(pks) == 0:
-                plpy.notice(f'no primary key in table {table_name}')
+                plpy.notice('no primary key in table '+table_name)
             elif len(pks) > 1:
-                plpy.notice(f'multi-column primary key in table {table_name}')
+                plpy.notice('multi-column primary key in table '+table_name)
             else:
-                event_id_sequence_name = f"{table_name}_{pks[0]['pk']}_seq"
+                event_id_sequence_name = table_name+"_"+pks[0]['pk']+"_seq"
                 rollup_column = pks[0]['pk']
         joininfo['rollup_column'] = rollup_column
         joininfo['event_id_sequence_name'] = event_id_sequence_name
 
         # verify that the computed sequence exists in the db
-        sql = f"SELECT relname FROM pg_class WHERE relkind = 'S' and relname='{event_id_sequence_name}';";
+        sql = "SELECT relname FROM pg_class WHERE relkind = 'S' and relname='"+event_id_sequence_name+"';";
         matches = list(plpy.execute(sql))
         if len(matches) == 0:
-            plpy.notice(f'sequence "{event_id_sequence_name}" not found in table')
+            plpy.notice('sequence "'+event_id_sequence_name+'" not found in table')
             event_id_sequence_name = None
             rollup_column = None
 
         # display warning messages
         if joininfo.get('rollup_column') is None:
-            plpy.notice(f'event_id_sequence_name={event_id_sequence_name}')
+            plpy.notice('event_id_sequence_name='+event_id_sequence_name)
             plpy.notice('no valid sequence found for manual/cron rollups; the only available rollup type is trigger')
 
     # verify that there are no subqueries
@@ -882,13 +882,13 @@ RETURNS TEXT AS $$
     ).create()
 
     # set the rollup mode
-    sqls += f"""
-    select rollup_mode('{rollup_name}','{mode}');
+    sqls += """
+    select rollup_mode('"""+rollup_name+"""','"""+mode+"""');
     """
 
     # insert values into the rollup
-    sqls += f"""
-    select {rollup_name}_raw_reset();
+    sqls += """
+    select """+rollup_name+"""_raw_reset();
     """
 
     if not dry_run:
@@ -905,12 +905,12 @@ CREATE OR REPLACE FUNCTION rollup_mode(
 )
 RETURNS VOID AS $func$
     
-    sql = (f"select * from pgrollup_rollups where rollup_name='{rollup_name}'")
+    sql = ("select * from pgrollup_rollups where rollup_name='"+rollup_name+"'")
     rows = list(plpy.execute(sql))
 
     for pgrollup in rows:
         if mode != 'trigger' and pgrollup['event_id_sequence_name'] is None:
-            plpy.error(f'''"mode" must be 'trigger' when "event_id_sequence_name" is NULL''')
+            plpy.error('''"mode" must be 'trigger' when "event_id_sequence_name" is NULL''')
 
         ########################################    
         # turn off the old mode
@@ -921,21 +921,21 @@ RETURNS VOID AS $func$
         # which is potentially an expensive operation.
         ########################################    
         if pgrollup['mode'] == 'trigger':
-            plpy.execute(f'''
-                SELECT pgrollup_unsafedroptriggers__{rollup_name}__{pgrollup['table_alias']}();
+            plpy.execute('''
+                SELECT pgrollup_unsafedroptriggers__'''+rollup_name+'''__'''+pgrollup['table_alias']+'''();
                 ''')
 
         if pgrollup['mode'] == 'cron':
-            plpy.execute(f'''
-                SELECT cron.unschedule('pgrollup.{rollup_name}');
-                ''')
-            plpy.execute(f"""
-                select do_rollup('{rollup_name}','{pgrollup['table_alias']}');
+            plpy.execute("""
+                SELECT cron.unschedule('pgrollup."""+rollup_name+"""');
+                """)
+            plpy.execute("""
+                select do_rollup('"""+rollup_name+"""','"""+pgrollup['table_alias']+"""');
                 """)
 
         if pgrollup['mode'] == 'manual':
-            plpy.execute(f"""
-                select do_rollup('{rollup_name}','{pgrollup['table_alias']}');
+            plpy.execute("""
+                select do_rollup('"""+rollup_name+"""','"""+pgrollup['table_alias']+"""');
                 """)
 
         ########################################    
@@ -944,34 +944,34 @@ RETURNS VOID AS $func$
         if mode=='cron':
             # we use a "random" delay on the cron job to ensure that all of the jobs
             # do not happen at the same time, overloading the database
-            sql = (f"""
+            sql = ("""
                 SELECT count(*) AS count
                 FROM cron.job
                 WHERE jobname ILIKE 'pgrollup.%';
                 """)
             num_jobs = plpy.execute(sql)[0]['count']
             delay = 13*num_jobs%60
-            plpy.execute(f'''
+            plpy.execute("""
                 SELECT cron.schedule(
-                    'pgrollup.{rollup_name}',
+                    'pgrollup."""+rollup_name+"""',
                     '* * * * *',
-                    $$SELECT do_rollup('{rollup_name}',delay_seconds=>{delay});$$
+                    $$SELECT do_rollup('"""+rollup_name+"""',delay_seconds=>"""+str(delay)+""");$$
                 );
-                ''')
+                """)
 
         if mode=='trigger':
 
             # first we do a manual rollup to ensure that the rollup table is up to date
             if pgrollup['event_id_sequence_name'] is not None:
-                plpy.execute(f"""
-                    select do_rollup('{rollup_name}','{pgrollup['table_alias']}');
+                plpy.execute("""
+                    select do_rollup('"""+rollup_name+"""','"""+pgrollup['table_alias']+"""');
                     """)
 
             # next we create triggers
             sql = 'select pgrollup_unsafecreatetriggers__'+rollup_name+'__'+pgrollup['table_alias']+'();'
             plpy.execute(sql)
 
-    plpy.execute(f"UPDATE pgrollup_rollups SET mode='{mode}' WHERE rollup_name='{rollup_name}';")
+    plpy.execute("UPDATE pgrollup_rollups SET mode='"+mode+"' WHERE rollup_name='"+rollup_name+"';")
 $func$
 LANGUAGE plpython3u;
 
@@ -1002,15 +1002,15 @@ RETURNS NULL ON NULL INPUT;
 
 CREATE OR REPLACE FUNCTION assert_rollup(rollup_name REGCLASS)
 RETURNS VOID AS $$
-    sql = f'select * from {rollup_name}_groundtruth except select * from {rollup_name};';
+    sql = 'select * from '+rollup_name+'_groundtruth except select * from '+rollup_name+';';
     res1 = plpy.execute(sql)
-    sql = f'select * from {rollup_name} except select * from {rollup_name}_groundtruth;';
+    sql = 'select * from '+rollup_name+' except select * from '+rollup_name+'_groundtruth;';
     res2 = plpy.execute(sql)
 
     for row in res1:
-        plpy.warning(f'result only in {rollup_name}_groundtruth: {str(row)}')
+        plpy.warning('result only in '+rollup_name+'_groundtruth: '+str(row))
     for row in res2:
-        plpy.warning(f'result only in {rollup_name}: {str(row)}')
+        plpy.warning('result only in '+rollup_name+': '+str(row))
 
     assert len(res1)==0
     assert len(res2)==0
@@ -1023,56 +1023,56 @@ $$ LANGUAGE 'sql' STRICT IMMUTABLE PARALLEL SAFE;
 
 
 CREATE OR REPLACE FUNCTION rollup_column_relative_error(rollup_name REGCLASS, column_name TEXT) RETURNS DOUBLE PRECISION AS $$
-    sql = f'select "{column_name}" from {rollup_name};';
+    sql = 'select "'+column_name+'" from '+rollup_name+';';
     res = plpy.execute(sql)
     assert len(res)==1
     val1 = res[0][column_name]
 
-    sql = f'select "{column_name}" from {rollup_name}_groundtruth;';
+    sql = 'select "'+column_name+'" from '+rollup_name+'_groundtruth;';
     res = plpy.execute(sql)
     assert len(res)==1
     val2 = res[0][column_name]
 
-    sql = f'select relative_error({val1},{val2}) as relative_error;';
+    sql = 'select relative_error('+str(val1)+','+str(val2)+') as relative_error;'; 
     res = plpy.execute(sql)
     return res[0]['relative_error']
 $$ LANGUAGE plpython3u STRICT IMMUTABLE PARALLEL SAFE;
 
 
 CREATE OR REPLACE FUNCTION assert_rollup_column_relative_error(rollup_name REGCLASS, column_name TEXT, relative_error DOUBLE PRECISION) RETURNS VOID AS $$
-    sql = f"select rollup_column_relative_error('{rollup_name}','{column_name}') as relative_error;";
+    sql = "select rollup_column_relative_error('"+rollup_name+"','"+column_name+"') as relative_error;";
     res = plpy.execute(sql)
     if not res[0]['relative_error'] < relative_error:
-        plpy.error(f"relative_error={res[0]['relative_error']} > {relative_error}")
+        plpy.error("relative_error="+res[0]['relative_error']+" > "+str(relative_error))
 $$ LANGUAGE plpython3u STRICT IMMUTABLE PARALLEL SAFE;
 
 
 CREATE OR REPLACE FUNCTION assert_rollup_relative_error(rollup_name REGCLASS, relative_error DOUBLE PRECISION) RETURNS VOID AS $$
-    sql = f"select * from {rollup_name} where true limit 1;"
+    sql = "select * from "+rollup_name+" where true limit 1;"
     res = plpy.execute(sql)
     columns = res[0].keys()
     plpy.error('columns={str(columns)}')
 
-    sql = f"select rollup_column_relative_error('{rollup_name}','{column_name}') as relative_error;";
+    sql = "select rollup_column_relative_error('"+rollup_name}+",'"+column_name}+") as relative_error;";
     res = plpy.execute(sql)
     if not res[0]['relative_error'] < relative_error:
-        plpy.error(f"relative_error={res[0]['relative_error']} > {relative_error}")
+        plpy.error("relative_error="+res[0]['relative_error']+" > "+str(relative_error))
 $$ LANGUAGE plpython3u STRICT IMMUTABLE PARALLEL SAFE;
 
 
 CREATE OR REPLACE FUNCTION assert_rollup_relative_error(rollup_name REGCLASS, relative_error DOUBLE PRECISION) RETURNS VOID AS $$
     # get a list of the columns in the rollup
-    sql = f"select * from {rollup_name} where true limit 1;"
+    sql = "select * from "+rollup_name+" where true limit 1;"
     res = plpy.execute(sql)
     columns = res[0].keys()
 
     # count the number of columns that do not satisfy the relative_error condition
     num_bad_columns = 0
     for column_name in columns:
-        sql = f"select rollup_column_relative_error('{rollup_name}','{column_name}') as relative_error;";
+        sql = "select rollup_column_relative_error('"+rollup_name+"','"+column_name+"') as relative_error;";
         res = plpy.execute(sql)
         if not res[0]['relative_error'] < relative_error:
-            plpy.warning(f"column {column_name} has relative_error={res[0]['relative_error']} > {relative_error}")
+            plpy.warning("column "+column_name+" has relative_error="+res[0]['relative_error']+" > "+str(relative_error))
             num_bad_columns+=1
 
     # the test case

--- a/pgrollup/__init__.py
+++ b/pgrollup/__init__.py
@@ -189,7 +189,7 @@ class Rollup:
     def create_table(self):
         temp_str = 'TEMPORARY ' if self.temporary else ''
         return (
-f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
+'''CREATE '''+temp_str+'''TABLE '''+self.rollup_table_name+''' (
     '''+
     (
     '''
@@ -277,11 +277,11 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
                 '''+
                 ''',
                 '''.join([
-                    ''+column.name+self._joinsub(f''' = CASE
-                        WHEN {self.rollup_table_name}."{column.algebra['name']}({column.value})" IS NOT NULL AND excluded."{column.algebra['name']}({column.value})" IS NOT NULL THEN {column.algebra['plus']}
-                        WHEN {self.rollup_table_name}."{column.algebra['name']}({column.value})" IS NOT NULL AND excluded."{column.algebra['name']}({column.value})" IS     NULL THEN {self.rollup_table_name}."{column.algebra['name']}({column.value})" 
-                        WHEN {self.rollup_table_name}."{column.algebra['name']}({column.value})" IS     NULL AND excluded."{column.algebra['name']}({column.value})" IS NOT NULL THEN excluded."{column.algebra['name']}({column.value})"
-                        WHEN {self.rollup_table_name}."{column.algebra['name']}({column.value})" IS     NULL AND excluded."{column.algebra['name']}({column.value})" IS     NULL THEN {column.algebra['zero']}
+                    ''+column.name+self._joinsub(''' = CASE
+                        WHEN '''+self.rollup_table_name+'''."'''+column.algebra['name']+'''('''+column.value+''')" IS NOT NULL AND excluded."'''+column.algebra['name']+'''('''+column.value+''')" IS NOT NULL THEN '''+column.algebra['plus']+'''
+                        WHEN '''+self.rollup_table_name+'''."'''+column.algebra['name']+'''('''+column.value+''')" IS NOT NULL AND excluded."'''+column.algebra['name']+'''('''+column.value+''')" IS     NULL THEN '''+self.rollup_table_name+'''."'''+column.algebra['name']+'''('''+column.value+''')" 
+                        WHEN '''+self.rollup_table_name+'''."'''+column.algebra['name']+'''('''+column.value+''')" IS     NULL AND excluded."'''+column.algebra['name']+'''('''+column.value+''')" IS NOT NULL THEN excluded."'''+column.algebra['name']+'''('''+column.value+''')"
+                        WHEN '''+self.rollup_table_name+'''."'''+column.algebra['name']+'''('''+column.value+''')" IS     NULL AND excluded."'''+column.algebra['name']+'''('''+column.value+''')" IS     NULL THEN '''+column.algebra['zero']+'''
                         END
                     ''',
                         self.rollup_table_name,
@@ -377,25 +377,25 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
                 END;
                 $$;
                 '''+
-                f'''INSERT INTO pgrollup_rollups 
-                    ( rollup_name
-                    , table_alias
-                    , table_name
+                """INSERT INTO pgrollup_rollups 
+                   ( rollup_name
+                   , table_alias
+                   , table_name
                     , rollup_column
                     , event_id_sequence_name
                     , sql
                     , mode
                     )
                     values 
-                    ( '{self.rollup_name}'
-                    , '{joininfo['table_alias']}'
-                    , '{joininfo['table_name']}'
-                    , '{joininfo['rollup_column'] or 'NULL' }'
-                    , '{joininfo['event_id_sequence_name'] or 'NULL' }'
-                    , '{function_name}'
+                    ( '"""+self.rollup_name+"""'
+                    , '"""+joininfo['table_alias']+"""'
+                    , '"""+joininfo['table_name']+"""'
+                    , '"""+(joininfo['rollup_column'] or 'NULL' )+"""'
+                    , '"""+(joininfo['event_id_sequence_name'] or 'NULL') +"""'
+                    , '"""+function_name+"""'
                     , 'init'
                     );
-                ''')
+                """)
         return '\n'.join(manualrollups)
 
 
@@ -533,8 +533,8 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
                 )
                 +
                 (
-                f'''
-                WHERE ({self.where_clause})
+                '''
+                WHERE ('''+self.where_clause+''')
                   AND ''' + new_where 
                 +
                 (
@@ -555,8 +555,8 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
                 if len(self.groups)>0 else ''
                 ) +
                 (
-                f'''
-                HAVING ({self.having_clause})
+                '''
+                HAVING ('''+self.having_clause+''')
                 '''
                 if self.having_clause else ''
                 )
@@ -608,8 +608,8 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
                 )
                 +
                 (
-                f'''
-                WHERE ({self.where_clause})'''
+                '''
+                WHERE ('''+self.where_clause+''')'''
                 +
                 (
                 '''
@@ -629,8 +629,8 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
                 if len(self.groups)>0 else ''
                 ) +
                 (
-                f'''
-                HAVING ({self.having_clause})
+                '''
+                HAVING ('''+self.having_clause+''')
                 '''
                 if self.having_clause else ''
                 )
@@ -695,13 +695,13 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
         ''')
 
     def create_drop(self):
-        return (f'''
-        CREATE OR REPLACE FUNCTION pgrollup_drop__'''+self.rollup_name+f'''()
+        return ('''
+        CREATE OR REPLACE FUNCTION pgrollup_drop__'''+self.rollup_name+'''()
         RETURNS VOID LANGUAGE PLPGSQL AS $$
             BEGIN
-            DROP TABLE {self.rollup_table_name} CASCADE;
-            DROP VIEW IF EXISTS {self.rollup}_groundtruth CASCADE;
-            DROP VIEW IF EXISTS {self.rollup}_groundtruth_raw CASCADE;
+            DROP TABLE '''+self.rollup_table_name+''' CASCADE;
+            DROP VIEW IF EXISTS '''+self.rollup+'''_groundtruth CASCADE;
+            DROP VIEW IF EXISTS '''+self.rollup+'''_groundtruth_raw CASCADE;
             '''
             +
             '''
@@ -710,11 +710,11 @@ f'''CREATE {temp_str}TABLE '''+self.rollup_table_name+''' (
                 DROP FUNCTION pgrollup_unsafecreatetriggers__'''+self.rollup_name+'__'+joininfo['table_alias']+''' CASCADE;'''
                 for joininfo in self.joininfos])
             +
-            f'''
-            DELETE FROM pgrollup_rollups WHERE rollup_name='{self.rollup}';
+            """
+            DELETE FROM pgrollup_rollups WHERE rollup_name='"""+self.rollup+"""';
         END;
         $$;
-        ''')
+        """)
 
     def create(self):
         return '\n\n'.join([

--- a/pgrollup/parser_pg.py
+++ b/pgrollup/parser_pg.py
@@ -1,0 +1,263 @@
+import sys
+from lark import Lark, Transformer
+
+def parse_create(sql):
+    '''
+    This is the main function that will get called from postgresql.
+    It converts the output of raw_parser into a list of dictionaries that contain the arguments for the create_view_internal function.
+    
+    >>> parse_create(sql0)
+    [{'joininfos': '[{"table_name": "tablename", "table_alias": "tablename", "condition": "", "join_type": "FROM"}]', 'groups': [['a', '"a"'], ['b', '"b"'], ['c', '"c"']], 'columns': [['count(*)', '"count(*)"'], ['sum(num)', 'sum']], 'where_clause': '(test>=from)', 'having_clause': '(foo=bar)'}]
+    >>> parse_create(sql1)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql2)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'groups': [['name', '"name"'], ['num', '"num"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql3)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'groups': [['name', '"name"']], 'columns': [['sum(num)', 'sum'], ['count(*)', 'count_all'], ['count(num)', '"count(num)"'], ['max(num)', '"max(num)"'], ['min(num)', '"min(num)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql4)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'groups': None, 'columns': [['sum(num)', 'sum'], ['count(*)', 'count_all'], ['count(num)', '"count(num)"'], ['max(num)', '"max(num)"'], ['min(num)', '"min(num)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql5)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'groups': None, 'columns': [['sum(num*num + 2)', '"sum(num*num + 2)"'], ['max(1)', '"max(1)"'], ['(max((1 +(((num))))*2)+ count(num))/count(*)+(max((1 +(((num))))*2)+ count(num))/count(*)', '"(max((1 +(((num))))*2)+ count(num))/count(*)+(max((1 +(((num))))*2)+ count(num))/count(*)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql6)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "testjoin1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "using (id)", "join_type": "INNER JOIN"}]', 'groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql7)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "INNER", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "on testjoin1.id=testjoin2.id", "join_type": "INNER JOIN"}]', groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql8)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "t1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "t2", "condition": "on testjoin1.id=testjoin2.id", "join_type": "INNER JOIN"}, {"table_name": "testjoin3", "table_alias": "t3", "condition": "on testjoin1.name=testjoin3.name", "join_type": "LEFT JOIN"}]', 'groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql9)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "testjoin1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "using (id)", "join_type": "FULL JOIN"}]', 'groups': [['name', '"name"']], 'columns': [['sum(num)', '"sum(num)"'], ['sum(foo)', '"sum(foo)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql10)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "testjoin1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "using (id)", "join_type": "INNER JOIN"}]', 'groups': [['name', '"name"']], 'columns': [['sum(num)', '"sum(num)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql11)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "t1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "t2", "condition": "using (id)", "join_type": "INNER JOIN"}]', 'groups': [['t1.name', '"t1.name"']], 'columns': [['sum(t1.num)', 'sum_num'], ['sum(t2.foo)', 'sum_foo']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql12)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "t1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin1", "table_alias": "t2", "condition": "on ((t1.id = t2.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t3", "condition": "on ((t2.id = t3.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t4", "condition": "on ((t3.id = t4.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t5", "condition": "on ((t4.id = t5.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t6", "condition": "on ((t5.id = t6.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t7", "condition": "on ((t6.id = t7.num))", "join_type": "INNER JOIN"}]', 'groups': [['t1.name', '"t1.name"']], 'columns': [['count(t1.num)', 'count_t1'], ['count(t2.num)', 'count_t2']], 'where_clause': None, 'having_clause': None}]
+    '''
+    parsed_output = parse(sql)
+    infos = []                                              
+    for x in parsed_output[0]['stmt']['targetList']:
+        if x['name']!= None:
+           alias = x['name'][1]
+        else:
+           alias = ''
+    
+    infos.append({
+        'joininfos' :_getjoins(parsed_output[0]['stmt']['fromClause'][0]),
+        'groups' : [[x['fields'][0],str(x['fields'][0])] for x in parsed_output[0]['stmt']['groupClause']] if parsed_output[0]['stmt']['groupClause'] != None else '',
+        'columns': [[expr_to_str(x['val']),alias] for x in parsed_output[0]['stmt']['targetList']],
+        'where_clause': expr_to_str(parsed_output[0]['stmt']['whereClause']) if parsed_output[0]['stmt']['whereClause'] != None else None,
+        'having_clause': expr_to_str(parsed_output[0]['stmt']['havingClause']) if parsed_output[0]['stmt']['havingClause'] != None else None,
+        })
+    return infos
+
+
+grammar = r"""
+    ?value: dict
+          | list
+          | ESCAPED_STRING     ->string
+          | NAME               -> name   
+          | SIGNED_NUMBER      -> number
+          | "true"             -> true
+          | "false"            -> false
+          | "<>"               -> null
+    
+    list: "(" [value*] ")"
+    dict: "{" value [pair*] "}"
+    pair : ":"NAME value
+
+    NAME: /[a-zA-Z_.0-9]+/
+    
+
+    %import common.ESCAPED_STRING
+    %import common.SIGNED_NUMBER
+    %import common.WS
+    %ignore WS
+    """
+
+
+class Transformer(Transformer):
+    '''
+    See https://lark-parser.readthedocs.io/en/latest/visitors.html    
+    '''
+    def string(self, s):
+        (s,) = s
+        return s[1:-1]
+    
+    
+    def number(self, n):
+        (n,) = n
+        return int(n)                        
+    
+    
+    def pair(self,key_value):
+        k, v = key_value
+        return str(k),v
+                       
+    list = list   
+    dict = dict
+    name  = lambda self,n: ('TYPE',str(n[0]))
+    null = lambda self, _: None
+    true = lambda self, _: True
+    false = lambda self, _: False
+
+parser = Lark(grammar, start='value', lexer='standard')
+
+
+def parse(text):
+    '''
+    This function is used to parse the output of raw_parser.
+    
+    >>> parse(sql0)
+    [{'TYPE': 'RAWSTMT', 'stmt': {'TYPE': 'SELECT', 'distinctClause': None, 'intoClause': None, 'targetList': [{'TYPE': 'RESTARGET', 'name': None, 'indirection': None, 'val': {'TYPE': 'FUNCCALL', 'funcname': ['count'], 'args': None, 'agg_order': None, 'agg_filter': None, 'agg_within_group': False, 'agg_star': True, 'agg_distinct': False, 'func_variadic': False, 'over': None, 'location': 16}, 'location': 16}, {'TYPE': 'RESTARGET', 'name': ('TYPE', 'sum'), 'indirection': None, 'val': {'TYPE': 'FUNCCALL', 'funcname': ['sum'], 'args': [{'TYPE': 'COLUMNREF', 'fields': ['num'], 'location': 38}], 'agg_order': None, 'agg_filter': None, 'agg_within_group': False, 'agg_star': False, 'agg_distinct': False, 'func_variadic': False, 'over': None, 'location': 34}, 'location': 34}], 'fromClause': [{'TYPE': 'RANGEVAR', 'schemaname': None, 'relname': ('TYPE', 'tablename'), 'inh': True, 'relpersistence': ('TYPE', 'p'), 'alias': None, 'location': 59}], 'whereClause': {'TYPE': 'AEXPR', 'name': ['>='], 'lexpr': {'TYPE': 'COLUMNREF', 'fields': ['test'], 'location': 80}, 'rexpr': {'TYPE': 'COLUMNREF', 'fields': ['from'], 'location': 86}, 'location': 84}, 'groupClause': [{'TYPE': 'COLUMNREF', 'fields': ['a'], 'location': 107}, {'TYPE': 'COLUMNREF', 'fields': ['b'], 'location': 109}, {'TYPE': 'COLUMNREF', 'fields': ['c'], 'location': 111}], 'havingClause': {'TYPE': 'AEXPR', 'name': ['='], 'lexpr': {'TYPE': 'COLUMNREF', 'fields': ['foo'], 'location': 124}, 'rexpr': {'TYPE': 'COLUMNREF', 'fields': ['bar'], 'location': 128}, 'location': 127}, 'windowClause': None, 'valuesLists': None, 'sortClause': None, 'limitOffset': None, 'limitCount': None, 'limitOption': 0, 'lockingClause': None, 'withClause': None, 'op': 0, 'all': False, 'larg': None, 'rarg': None}, 'stmt_location': 0, 'stmt_len': 132}]
+    '''
+    tree = parser.parse(text)
+    return Transformer().transform(tree)
+
+
+def parse_tree(text):
+    print(parser.parse(text).pretty())
+
+################################################################################
+# internal helper functions
+################################################################################
+
+def expr_to_str(expr):
+    '''
+    This function transforms expressions into strings.
+    
+    >>> assert expr_to_str(parse(sql0)[0]['stmt']['havingClause'])
+    '(foo=bar)' 
+    '''
+    if expr['TYPE']=='A_CONST':
+        return str(expr['val'])
+    elif expr['TYPE']=='COLUMNREF':
+        return str(expr['fields'][0])
+    elif expr['TYPE']=='FUNCCALL':
+        if expr['agg_star']==True:
+            return expr['funcname'][0]+'(*)'
+        else:
+            return expr['funcname'][0]+'('+expr_to_str(expr['args'][0])+')'
+    elif expr['TYPE']=='AEXPR':
+        return '('+expr_to_str(expr['lexpr']) + expr['name'][0] + expr_to_str(expr['rexpr'])+')'
+
+
+def _getjointype(info):
+    '''
+    This function returns a query's join type.
+    '''
+    if info['jointype'] == 0:
+        return "INNER JOIN"
+    elif info['jointype'] ==1:
+        return "OUTER JOIN"
+    elif info['jointype'] ==2:
+        return "FULL JOIN"
+
+
+def _getjoins(info):
+    '''
+    This function generates a list that contains join information.
+    
+    >>> _getjoins(parse(sql7)[0]['stmt']['fromClause'][0])
+    [[{'table_name': 'testjoin1', 'table_alias': 'testjoin1', 'condition': '', 'join_type': 'FROM'}], [{'table_name': 'testjoin2', 'table_alias': 'testjoin2', 'condition': 'on(testjoin1=testjoin2)', 'join_type': 'INNER JOIN'}]]
+    '''
+    join_infos = []
+    if info['TYPE']=='RANGEVAR':
+        table_name = str(info['relname'][1])
+        if info['alias']!= None:
+            table_alias=str(info['alias']['aliasname'][1])
+        else:    
+            table_alias = str(info['relname'][1])
+        join_type= 'FROM'
+        condition= ''
+        join_info = {
+            'table_name': table_name,
+            'table_alias': table_alias,
+            'condition': condition,
+            'join_type': join_type
+       }
+        join_infos.append(join_info)
+        return join_infos
+    elif info['TYPE']=='JOINEXPR':
+        if info['usingClause']!= None:
+            condition = 'using('+str(info['usingClause'])+')'
+        else:
+            condition = 'on'+expr_to_str(info['quals'])
+        larg = _getjoins(info['larg'])
+        rarg = _getjoins(info['rarg'])
+        rarg[0]['join_type'] = _getjointype(info)
+        if info['usingClause']!= None:
+            rarg[0]['condition'] = 'using('+str(info['usingClause'][0])+')'
+        else:
+            rarg[0]['condition'] = 'on'+expr_to_str(info['quals'])
+        join_infos.append(larg)
+        join_infos.append(rarg)
+        return join_infos
+              
+################################################################################
+# postgres's parse tree on example sql expressions
+################################################################################
+
+#sql0 = '''
+#CREATE INCREMENTAL MATERIALIZED VIEW example AS (
+#    SELECT
+#        count(*),
+#        sum(num) AS sum
+#    FROM tablename
+#    WHERE (test>=from)
+#    GROUP BY a,b,c
+#    HAVING foo=bar
+#);
+#'''
+sql0='''
+ ({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16} {RESTARGET :name sum :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 38}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 34} :location 34}) :fromClause ({RANGEVAR :schemaname <> :relname tablename :inh true :relpersistence p :alias <> :location 59}) :whereClause {AEXPR  :name (">=") :lexpr {COLUMNREF :fields ("test") :location 80} :rexpr {COLUMNREF :fields ("from") :location 86} :location 84} :groupClause ({COLUMNREF :fields ("a") :location 107} {COLUMNREF :fields ("b") :location 109} {COLUMNREF :fields ("c") :location 111}) :havingClause {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("foo") :location 124} :rexpr {COLUMNREF :fields ("bar") :location 128} :location 127} :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 132})
+'''
+
+sql1='''
+ ({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 43}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 68}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause<> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 73})
+'''
+
+sql2='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 8} :location 8}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 35}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 60} {COLUMNREF :fields ("num") :location 65}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 69})
+'''
+
+sql3='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name sum :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 21}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 17} :location 17} {RESTARGET :name count_all :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 42} :location 42} {RESTARGET :name <> :indirection <> :val{FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 79}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 73} :location 73} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("max") :args ({COLUMNREF :fields ("num") :location 97}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 93} :location 93} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("min") :args ({COLUMNREF :fields ("num") :location 115}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 111} :location 111}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 129}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 154}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 159})
+'''
+
+sql4='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name sum :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 20}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 16} :location 16} {RESTARGET :name count_all :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 41} :location 41} {RESTARGET :name <> :indirection <> :val{FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 78}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 72} :location 72} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("max") :args ({COLUMNREF :fields ("num") :location 96}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 92} :location 92} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("min") :args ({COLUMNREF :fields ("num") :location 114}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 110} :location 110}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 128}) :whereClause <> :groupClause <> :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 140})
+'''
+
+sql5='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({AEXPR  :name ("+") :lexpr {AEXPR  :name ("*") :lexpr {COLUMNREF :fields ("num") :location 20} :rexpr {COLUMNREF :fields ("num") :location 24} :location 23} :rexpr {A_CONST :val 2 :location 30} :location 28}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 16} :location 16} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("max") :args ({A_CONST :val 1 :location 46}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 42} :location 42} {RESTARGET :name <> :indirection <> :val {AEXPR  :name ("+") :lexpr {AEXPR  :name ("/") :lexpr {AEXPR  :name ("+") :lexpr {FUNCCALL :funcname ("max") :args ({AEXPR  :name ("*") :lexpr {AEXPR  :name ("+") :lexpr {A_CONST :val 1 :location 64} :rexpr {COLUMNREF :fields ("num") :location 71} :location 66} :rexpr {A_CONST :val 2 :location 79} :location 78}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 59} :rexpr {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 90}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 84} :location 82} :rexpr {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 96} :location 95} :rexpr {AEXPR  :name ("/") :lexpr {AEXPR  :name ("+") :lexpr {FUNCCALL :funcname ("max") :args ({AEXPR  :name ("*") :lexpr {AEXPR  :name ("+") :lexpr {A_CONST :val 1 :location 121} :rexpr {COLUMNREF :fields ("num") :location 128} :location 123} :rexpr {A_CONST :val 2 :location 136} :location 135}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 116} :rexpr {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("num") :location 147}) :agg_order <> :agg_filter <> :agg_within_group false:agg_star false :agg_distinct false :func_variadic false :over <> :location 141} :location 139} :rexpr {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 153} :location 152} :location 113} :location 58}) :fromClause ({RANGEVAR :schemaname <> :relname testparsing :inh true :relpersistence p :alias <> :location 171}) :whereClause <> :groupClause <> :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 184})
+ '''
+
+sql6='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 17} :location 17}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 44} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 63} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 97}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 102})
+'''
+
+sql7='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 43} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 68} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("testjoin1" "id") :location 81} :rexpr {COLUMNREF :fields ("testjoin2" "id") :location 94} :location 93} :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 120}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 125})
+'''
+
+sql8='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count :indirection <> :val {FUNCCALL :funcname ("count") :args <> :agg_order <> :agg_filter <> :agg_within_group false :agg_star true :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({JOINEXPR :jointype 1 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t1 :colnames <>} :location 43} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias {ALIAS :aliasname t2 :colnames <>} :location 74} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("testjoin1" "id") :location 93} :rexpr {COLUMNREF :fields ("testjoin2" "id") :location 106} :location 105} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin3 :inh true :relpersistence p :alias {ALIAS :aliasname t3 :colnames <>} :location 139} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("testjoin1" "name") :location 158} :rexpr {COLUMNREF :fields ("testjoin3" "name") :location 173} :location 172} :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 201}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 207})
+'''
+
+sql9='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 21}) :agg_order <>:agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 17} :location 17} {RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("foo") :location 39}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 35} :location 35}) :fromClause ({JOINEXPR :jointype 2 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 53} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 77} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 111}) :havingClause <> :windowClause <>:valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 116})
+'''
+
+sql10='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name <> :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("num") :location 20}) :agg_order <>:agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 16} :location 16}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias <> :location 34} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias <> :location 53} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("name") :location 87}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <>:limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 92})
+'''
+
+sql11='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name sum_num :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("t1" "num") :location 12}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 8} :location 8} {RESTARGET :name sum_foo :indirection <> :val {FUNCCALL :funcname ("sum") :args ({COLUMNREF :fields ("t2" "foo") :location 40}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 36} :location 36}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t1 :colnames <>} :location 68} :rarg {RANGEVAR :schemaname <> :relname testjoin2 :inh true :relpersistence p :alias {ALIAS :aliasname t2 :colnames <>} :location 91} :usingClause ("id") :quals <> :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("t1" "name") :location 127}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 135})
+'''
+
+sql12='''
+({RAWSTMT :stmt {SELECT :distinctClause <> :intoClause <> :targetList ({RESTARGET :name count_t1 :indirection <> :val {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("t1" "num") :location 14}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 8} :location 8} {RESTARGET :name count_t2 :indirection <> :val {FUNCCALL :funcname ("count") :args ({COLUMNREF :fields ("t2" "num") :location 45}) :agg_order <> :agg_filter <> :agg_within_group false :agg_star false :agg_distinct false :func_variadic false :over <> :location 39}:location 39}) :fromClause ({JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {JOINEXPR :jointype 0 :isNatural false :larg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t1 :colnames<>} :location 79} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t2 :colnames <>} :location 102} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t1" "id") :location 120} :rexpr {COLUMNREF :fields ("t2" "num") :location 128} :location 126} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t3 :colnames <>} :location 148} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t2" "id") :location 166} :rexpr {COLUMNREF :fields ("t3" "num") :location 174} :location 172} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t4 :colnames <>} :location 194} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t3" "id") :location 212} :rexpr {COLUMNREF :fields ("t4" "num") :location 220} :location 218} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t5 :colnames <>} :location 240} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t4" "id") :location 258} :rexpr {COLUMNREF :fields ("t5" "num") :location 266} :location 264} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t6 :colnames <>} :location 286} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t5" "id") :location 304} :rexpr {COLUMNREF :fields ("t6" "num") :location 312} :location 310} :alias <> :rtindex 0} :rarg {RANGEVAR :schemaname <> :relname testjoin1 :inh true :relpersistence p :alias {ALIAS :aliasname t7 :colnames <>} :location 332} :usingClause <> :quals {AEXPR  :name ("=") :lexpr {COLUMNREF :fields ("t6" "id") :location 350} :rexpr {COLUMNREF :fields ("t7" "num") :location 358} :location 356} :alias <> :rtindex 0}) :whereClause <> :groupClause ({COLUMNREF :fields ("t1" "name") :location 379}) :havingClause <> :windowClause <> :valuesLists <> :sortClause <> :limitOffset <> :limitCount <> :limitOption 0 :lockingClause <> :withClause <> :op 0 :all false :larg <> :rarg <>} :stmt_location 0 :stmt_len 388})
+'''
+
+

--- a/pgrollup/parsing.py
+++ b/pgrollup/parsing.py
@@ -29,6 +29,31 @@ def parse_create(text):
     >>> assert parse_create(sql12)
     >>> len(parse_create(sql0+sql1+sql2+sql3+sql4))
     5
+    >>> parse_create(sql0)
+    [{'joininfos': '[{"table_name": "tablename", "table_alias": "tablename", "condition": "", "join_type": "FROM"}]', 'rollup_name': 'example', 'groups': [['a', '"a"'], ['b', '"b"'], ['c', '"c"']], 'columns': [['count(*)', '"count(*)"'], ['sum(num)', 'sum']], 'where_clause': '(test>=from)', 'having_clause': 'foo=bar'}]
+    >>> parse_create(sql1)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'rollup_name': 'testparsing_rollup1', 'groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql2)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'rollup_name': 'testparsing_rollup2', 'groups': [['name', '"name"'], ['num', '"num"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql3)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'rollup_name': 'testparsing_rollup3', 'groups': [['name', '"name"']], 'columns': [['sum(num)', 'sum'], ['count(*)', 'count_all'], ['count(num)', '"count(num)"'], ['max(num)', '"max(num)"'], ['min(num)', '"min(num)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql4)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'rollup_name': 'testparsing_rollup4', 'groups': None, 'columns': [['sum(num)', 'sum'], ['count(*)', 'count_all'], ['count(num)', '"count(num)"'], ['max(num)', '"max(num)"'], ['min(num)', '"min(num)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql5)
+    [{'joininfos': '[{"table_name": "testparsing", "table_alias": "testparsing", "condition": "", "join_type": "FROM"}]', 'rollup_name': 'testparsing_rollup7', 'groups': None, 'columns': [['sum(num*num + 2)', '"sum(num*num + 2)"'], ['max(1)', '"max(1)"'], ['(max((1 +(((num))))*2)+ count(num))/count(*)+(max((1 +(((num))))*2)+ count(num))/count(*)', '"(max((1 +(((num))))*2)+ count(num))/count(*)+(max((1 +(((num))))*2)+ count(num))/count(*)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql6)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "testjoin1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "using (id)", "join_type": "INNER JOIN"}]', 'rollup_name': 'testparsing_rollup7', 'groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql7)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "INNER", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "on testjoin1.id=testjoin2.id", "join_type": "INNER JOIN"}]', 'rollup_name': 'testparsing_rollup7', 'groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql8)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "t1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "t2", "condition": "on testjoin1.id=testjoin2.id", "join_type": "INNER JOIN"}, {"table_name": "testjoin3", "table_alias": "t3", "condition": "on testjoin1.name=testjoin3.name", "join_type": "LEFT JOIN"}]', 'rollup_name': 'testparsing_rollup7', 'groups': [['name', '"name"']], 'columns': [['count(*)', 'count']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql9)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "FULL", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "using (id)", "join_type": "INNER JOIN"}]', 'rollup_name': 'testparsing_rollup7', 'groups': [['name', '"name"']], 'columns': [['sum(num)', '"sum(num)"'], ['sum(foo)', '"sum(foo)"']], 'where_clause': None, 'having_clause': None}]    >>> parse_create(sql10)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "testjoin1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "testjoin2", "condition": "using (id)", "join_type": "INNER JOIN"}]', 'rollup_name': 'testparsing_rollup7', 'groups': [['name', '"name"']], 'columns': [['sum(num)', '"sum(num)"']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql11)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "t1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin2", "table_alias": "t2", "condition": "using (id)", "join_type": "INNER JOIN"}]', 'rollup_name': 'testjoin_rollup1', 'groups': [['t1.name', '"t1.name"']], 'columns': [['sum(t1.num)', 'sum_num'], ['sum(t2.foo)', 'sum_foo']], 'where_clause': None, 'having_clause': None}]
+    >>> parse_create(sql12)
+    [{'joininfos': '[{"table_name": "testjoin1", "table_alias": "t1", "condition": "", "join_type": "FROM"}, {"table_name": "testjoin1", "table_alias": "t2", "condition": "on ((t1.id = t2.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t3", "condition": "on ((t2.id = t3.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t4", "condition": "on ((t3.id = t4.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t5", "condition": "on ((t4.id = t5.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t6", "condition": "on ((t5.id = t6.num))", "join_type": "INNER JOIN"}, {"table_name": "testjoin1", "table_alias": "t7", "condition": "on ((t6.id = t7.num))", "join_type": "INNER JOIN"}]', 'rollup_name': 'testjoin_rollup3', 'groups': [['t1.name', '"t1.name"']], 'columns': [['count(t1.num)', 'count_t1'], ['count(t2.num)', 'count_t2']], 'where_clause': None, 'having_clause': None}]
     '''
     tree = grammar.parse(text)
     infos = []

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.6',
+    python_requires='>=3.5',
 )


### PR DESCRIPTION
A few modifications on parser_pg's parser_create doctests:
1. For sql0, the output of having_clause changed from 'foo=bar' to '(foo=bar)'
2. For sql9, the original output of the first table's alias is wrong, so it's modified from 'FULL' to 'testjoin1', it's join type is also changed from 'INNER JOIN' to 'FULL JOIN'
3. All rollup table names are removed